### PR TITLE
fix ActionView::Template::Error

### DIFF
--- a/lib/subtask_list_columns_lib.rb
+++ b/lib/subtask_list_columns_lib.rb
@@ -9,6 +9,10 @@ module SubtaskListColumnsLib
             unloadable
 
             alias_method_chain :render_descendants_tree, :listed
+            alias_method :get_fields_for_project, :get_fields_for_project
+            alias_method :remove_unavailable_custom_fields, :remove_unavailable_custom_fields
+            alias_method :get_first_column_in_table, :get_first_column_in_table
+            alias_method :get_td, :get_td
       end
     end
 


### PR DESCRIPTION
Make changes recommended by https://github.com/SMS-IT/redmine_subtask_list_columns/issues/5#issuecomment-237262089 to fix ActionView::Template::Error (undefined method get_fields_for_project